### PR TITLE
Separated provider versioning and configuration

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,11 @@
+provider "azurerm" {
+  alias = "child"
+  subscription_id = var.child_domain_subscription_id
+  features {}
+}
+
+provider "azurerm" {
+  alias = "parent"
+  subscription_id = var.parent_domain_subscription_id
+  features {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.10"
+  required_version = ">= 0.13.0"
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"

--- a/versions.tf
+++ b/versions.tf
@@ -1,17 +1,9 @@
 terraform {
   required_version = ">= 0.12.10"
-}
-
-provider "azurerm" {
-  alias = "child"
-  subscription_id = var.child_domain_subscription_id
-  version = ">= 2.0.0"
-  features {}
-}
-
-provider "azurerm" {
-  alias = "parent"
-  subscription_id = var.parent_domain_subscription_id
-  version = ">= 2.0.0"
-  features {}
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = ">= 2.0.0"
+    }
+  }
 }


### PR DESCRIPTION
Provider configuration separated into `provider.tf` file, `versions.tf` only includes required version now. Resolves https://github.com/Azure-Terraform/terraform-azurerm-dns-zone/issues/4